### PR TITLE
Support multiple forms

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/Counter.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/Counter.kt
@@ -7,7 +7,6 @@ import com.cobblemon.mod.common.api.events.pokeball.PokemonCatchRateEvent
 import com.cobblemon.mod.common.api.events.pokemon.PokemonCapturedEvent
 import com.cobblemon.mod.common.api.pokeball.PokeBalls
 import com.cobblemon.mod.common.api.storage.player.PlayerDataExtensionRegistry
-import com.cobblemon.mod.common.command.argument.PokemonArgumentType
 import com.cobblemon.mod.common.command.argument.PokemonPropertiesArgumentType
 import com.cobblemon.mod.common.util.getPlayer
 import net.fabricmc.api.ModInitializer

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/Counter.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/Counter.kt
@@ -8,6 +8,7 @@ import com.cobblemon.mod.common.api.events.pokemon.PokemonCapturedEvent
 import com.cobblemon.mod.common.api.pokeball.PokeBalls
 import com.cobblemon.mod.common.api.storage.player.PlayerDataExtensionRegistry
 import com.cobblemon.mod.common.command.argument.PokemonArgumentType
+import com.cobblemon.mod.common.command.argument.PokemonPropertiesArgumentType
 import com.cobblemon.mod.common.util.getPlayer
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback
@@ -21,10 +22,7 @@ import org.apache.logging.log4j.Logger
 import us.timinc.mc.cobblemon.counter.api.CaptureApi
 import us.timinc.mc.cobblemon.counter.command.*
 import us.timinc.mc.cobblemon.counter.config.CounterConfig
-import us.timinc.mc.cobblemon.counter.store.CaptureCount
-import us.timinc.mc.cobblemon.counter.store.CaptureStreak
-import us.timinc.mc.cobblemon.counter.store.KoCount
-import us.timinc.mc.cobblemon.counter.store.KoStreak
+import us.timinc.mc.cobblemon.counter.store.*
 import java.util.*
 
 object Counter : ModInitializer {
@@ -44,105 +42,57 @@ object Counter : ModInitializer {
         CobblemonEvents.BATTLE_FAINTED.subscribe { handleWildDefeat(it) }
         CobblemonEvents.POKEMON_CATCH_RATE.subscribe { repeatBallBooster(it) }
         CommandRegistrationCallback.EVENT.register { dispatcher, _, _ ->
-            dispatcher.register(
-                literal("counter").then(
-                    literal("ko").then(
-                        literal("count")
-                            .then(
-                                argument("species", PokemonArgumentType.pokemon())
-                                    .then(
-                                        argument("player", EntityArgumentType.player())
-                                            .executes { KoCountCommand.withPlayer(it) }
-                                    )
-                                    .executes { KoCountCommand.withoutPlayer(it) }
-                            )
-                    ).then(
-                        literal("streak")
-                            .then(
-                                argument("player", EntityArgumentType.player())
-                                    .executes { KoStreakCommand.withPlayer(it) }
-                            )
-                            .executes { KoStreakCommand.withoutPlayer(it) }
+            dispatcher.register(literal("counter").then(literal("ko").then(literal("count").then(argument(
+                Commands.PROPERTIES, PokemonPropertiesArgumentType.properties()
+            ).then(argument(
+                "player", EntityArgumentType.player()
+            ).executes { KoCountCommand.withPlayer(it) }).executes { KoCountCommand.withoutPlayer(it) })
+            ).then(literal("streak").then(argument(
+                    "player", EntityArgumentType.player()
+                ).executes { KoStreakCommand.withPlayer(it) }).executes { KoStreakCommand.withoutPlayer(it) }
 
+                ).then(literal("total").then(argument(
+                    "player", EntityArgumentType.player()
+                ).executes { KoTotalCommand.withPlayer(it) }).executes { KoTotalCommand.withoutPlayer(it) })
+                .then(literal("reset").requires { source -> source.hasPermissionLevel(2) }.then(
+                        literal("count").then(argument(
+                            "player", EntityArgumentType.player()
+                        ).executes { KoResetCommand.resetCount(it) })
                     ).then(
-                        literal("total")
-                            .then(
-                                argument("player", EntityArgumentType.player())
-                                    .executes { KoTotalCommand.withPlayer(it) }
-                            )
-                            .executes { KoTotalCommand.withoutPlayer(it) }
+                        literal("streak").then(argument(
+                            "player", EntityArgumentType.player()
+                        ).executes { KoResetCommand.resetStreak(it) })
                     ).then(
-                        literal("reset")
-                            .requires { source -> source.hasPermissionLevel(2) }
-                            .then(
-                                literal("count")
-                                    .then(
-                                        argument("player", EntityArgumentType.player())
-                                            .executes { KoResetCommand.resetCount(it) }
-                                    )
-                            )
-                            .then(
-                                literal("streak")
-                                    .then(
-                                        argument("player", EntityArgumentType.player())
-                                            .executes { KoResetCommand.resetStreak(it) }
-                                    )
-                            )
-                            .then(
-                                literal("all").then(
-                                    argument("player", EntityArgumentType.player())
-                                        .executes { KoResetCommand.reset(it) }
-                                )
-                            )
+                        literal("all").then(argument(
+                            "player", EntityArgumentType.player()
+                        ).executes { KoResetCommand.reset(it) })
                     )
-                ).then(
-                    literal("capture").then(
-                        literal("count")
-                            .then(
-                                argument("species", PokemonArgumentType.pokemon())
-                                    .then(
-                                        argument("player", EntityArgumentType.player())
-                                            .executes { CaptureCountCommand.withPlayer(it) }
-                                    )
-                                    .executes { CaptureCountCommand.withoutPlayer(it) }
-                            )
-                    ).then(
-                        literal("streak")
-                            .then(
-                                argument("player", EntityArgumentType.player())
-                                    .executes { CaptureStreakCommand.withPlayer(it) }
-                            )
-                            .executes { CaptureStreakCommand.withoutPlayer(it) }
-                    ).then(
-                        literal("total")
-                            .then(
-                                argument("player", EntityArgumentType.player())
-                                    .executes { CaptureTotalCommand.withPlayer(it) }
-                            )
-                            .executes { CaptureTotalCommand.withoutPlayer(it) }
-                    ).then(
-                        literal("reset")
-                            .requires { source -> source.hasPermissionLevel(2) }
-                            .then(
-                                literal("count")
-                                    .then(
-                                        argument("player", EntityArgumentType.player())
-                                            .executes { CaptureResetCommand.resetCount(it) }
-                                    )
-                            )
-                            .then(
-                                literal("streak")
-                                    .then(
-                                        argument("player", EntityArgumentType.player())
-                                            .executes { CaptureResetCommand.resetStreak(it) }
-                                    )
-                            )
-                            .then(
-                                literal("all").then(
-                                    argument("player", EntityArgumentType.player())
-                                        .executes { CaptureResetCommand.reset(it) }
-                                )
-                            )
+                )
+            ).then(literal("capture").then(literal("count").then(argument(
+                    Commands.PROPERTIES, PokemonPropertiesArgumentType.properties()
+                ).then(argument(
+                    "player", EntityArgumentType.player()
+                ).executes { CaptureCountCommand.withPlayer(it) }).executes { CaptureCountCommand.withoutPlayer(it) })
+                ).then(literal("streak").then(argument(
+                    "player", EntityArgumentType.player()
+                ).executes { CaptureStreakCommand.withPlayer(it) }).executes { CaptureStreakCommand.withoutPlayer(it) })
+                    .then(literal("total").then(argument(
+                        "player", EntityArgumentType.player()
+                    ).executes { CaptureTotalCommand.withPlayer(it) })
+                        .executes { CaptureTotalCommand.withoutPlayer(it) })
+                    .then(literal("reset").requires { source -> source.hasPermissionLevel(2) }.then(
+                            literal("count").then(argument(
+                                "player", EntityArgumentType.player()
+                            ).executes { CaptureResetCommand.resetCount(it) })
+                        ).then(
+                            literal("streak").then(argument(
+                                "player", EntityArgumentType.player()
+                            ).executes { CaptureResetCommand.resetStreak(it) })
+                        ).then(
+                            literal("all").then(argument(
+                                "player", EntityArgumentType.player()
+                            ).executes { CaptureResetCommand.reset(it) })
+                        )
                     )
                 )
             )
@@ -154,8 +104,10 @@ object Counter : ModInitializer {
 
         if (thrower !is ServerPlayerEntity) return
 
+        val pokemon = event.pokemonEntity.pokemon
+
         if (event.pokeBallEntity.pokeBall == PokeBalls.REPEAT_BALL && CaptureApi.getCount(
-                thrower, event.pokemonEntity.pokemon.species.name.lowercase()
+                thrower, PokemonIdentifier(pokemon.species.name, pokemon.form.name)
             ) > 0
         ) {
             event.catchRate *= 2.5f
@@ -163,28 +115,32 @@ object Counter : ModInitializer {
     }
 
     private fun handlePokemonCapture(event: PokemonCapturedEvent) {
-        val species = event.pokemon.species.name.lowercase()
+        val pokemonId = PokemonIdentifier(event.pokemon.species.name, event.pokemon.form.name)
 
         val data = Cobblemon.playerData.get(event.player)
 
         val captureCount: CaptureCount = data.extraData.getOrPut(CaptureCount.NAME) { CaptureCount() } as CaptureCount
-        captureCount.add(species)
+        captureCount.add(pokemonId)
 
         val captureStreak: CaptureStreak =
             data.extraData.getOrPut(CaptureStreak.NAME) { CaptureStreak() } as CaptureStreak
-        captureStreak.add(species)
+        captureStreak.add(pokemonId)
 
         info(
-            "Player ${event.player.displayName.string} captured a $species streak(${captureStreak.count}) count(${
+            "Player ${event.player.displayName.string} captured a $pokemonId streak(${captureStreak.count}) count(${
                 captureCount.get(
-                    species
+                    pokemonId
                 )
             })"
         )
         if (config.broadcastCapturesToPlayer) {
             event.player.sendMessage(
                 Text.translatable(
-                    "counter.capture.confirm", species, captureCount.get(species), captureStreak.count
+                    "counter.capture.confirm",
+                    pokemonId.species,
+                    pokemonId.form,
+                    captureCount.get(pokemonId),
+                    captureStreak.count
                 )
             )
         }
@@ -198,27 +154,27 @@ object Counter : ModInitializer {
         if (!targetPokemon.isWild()) {
             return
         }
-        val species = targetPokemon.species.name.lowercase()
+        val pokemonId = PokemonIdentifier(targetPokemon.species.name, targetPokemon.form.name)
 
         event.battle.playerUUIDs.mapNotNull(UUID::getPlayer).forEach { player ->
             val data = Cobblemon.playerData.get(player)
             val koCount: KoCount = data.extraData.getOrPut(KoCount.NAME) { KoCount() } as KoCount
             val koStreak: KoStreak = data.extraData.getOrPut(KoStreak.NAME) { KoStreak() } as KoStreak
 
-            koCount.add(species)
-            koStreak.add(species)
+            koCount.add(pokemonId)
+            koStreak.add(pokemonId)
 
             info(
-                "Player ${player.displayName.string} KO'd a $species streak(${koStreak.count}) count(${
+                "Player ${player.displayName.string} KO'd a $pokemonId streak(${koStreak.count}) count(${
                     koCount.get(
-                        species
+                        pokemonId
                     )
                 })"
             )
             if (config.broadcastKosToPlayer) {
                 player.sendMessage(
                     Text.translatable(
-                        "counter.ko.confirm", species, koCount.get(species), koStreak.count
+                        "counter.ko.confirm", pokemonId.species, pokemonId.form, koCount.get(pokemonId), koStreak.count
                     )
                 )
             }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CaptureApi.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/CaptureApi.kt
@@ -4,6 +4,7 @@ import com.cobblemon.mod.common.Cobblemon
 import net.minecraft.entity.player.PlayerEntity
 import us.timinc.mc.cobblemon.counter.store.CaptureCount
 import us.timinc.mc.cobblemon.counter.store.CaptureStreak
+import us.timinc.mc.cobblemon.counter.store.PokemonIdentifier
 
 object CaptureApi {
     fun getTotal(player: PlayerEntity): Int {
@@ -11,15 +12,17 @@ object CaptureApi {
         return (playerData.extraData.getOrPut(CaptureCount.NAME) { CaptureCount() } as CaptureCount).total()
     }
 
-    fun getCount(player: PlayerEntity, species: String): Int {
+    fun getCount(player: PlayerEntity, pokemonId: PokemonIdentifier): Int {
         val playerData = Cobblemon.playerData.get(player)
-        return (playerData.extraData.getOrPut(CaptureCount.NAME) { CaptureCount() } as CaptureCount).get(species)
+        return (playerData.extraData.getOrPut(CaptureCount.NAME) { CaptureCount() } as CaptureCount).get(
+            pokemonId
+        )
     }
 
-    fun getStreak(player: PlayerEntity): Pair<String, Int> {
+    fun getStreak(player: PlayerEntity): Pair<PokemonIdentifier, Int> {
         val playerData = Cobblemon.playerData.get(player)
         val captureStreakData = (playerData.extraData.getOrPut(CaptureStreak.NAME) { CaptureStreak() } as CaptureStreak)
-        return Pair(captureStreakData.species, captureStreakData.count)
+        return Pair(captureStreakData.pokemonId, captureStreakData.count)
     }
 
     fun resetCount(player: PlayerEntity) {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/KoApi.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/api/KoApi.kt
@@ -4,6 +4,7 @@ import com.cobblemon.mod.common.Cobblemon
 import net.minecraft.entity.player.PlayerEntity
 import us.timinc.mc.cobblemon.counter.store.KoCount
 import us.timinc.mc.cobblemon.counter.store.KoStreak
+import us.timinc.mc.cobblemon.counter.store.PokemonIdentifier
 
 object KoApi {
     fun getTotal(player: PlayerEntity): Int {
@@ -11,15 +12,15 @@ object KoApi {
         return (playerData.extraData.getOrPut(KoCount.NAME) { KoCount() } as KoCount).total()
     }
 
-    fun getCount(player: PlayerEntity, species: String): Int {
+    fun getCount(player: PlayerEntity, pokemonId: PokemonIdentifier): Int {
         val playerData = Cobblemon.playerData.get(player)
-        return (playerData.extraData.getOrPut(KoCount.NAME) { KoCount() } as KoCount).get(species)
+        return (playerData.extraData.getOrPut(KoCount.NAME) { KoCount() } as KoCount).get(pokemonId)
     }
 
-    fun getStreak(player: PlayerEntity): Pair<String, Int> {
+    fun getStreak(player: PlayerEntity): Pair<PokemonIdentifier, Int> {
         val playerData = Cobblemon.playerData.get(player)
         val koStreakData = (playerData.extraData.getOrPut(KoStreak.NAME) { KoStreak() } as KoStreak)
-        return Pair(koStreakData.species, koStreakData.count)
+        return Pair(koStreakData.pokemonId, koStreakData.count)
     }
 
     fun resetCount(player: PlayerEntity) {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/CaptureCountCommand.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/CaptureCountCommand.kt
@@ -1,35 +1,43 @@
 package us.timinc.mc.cobblemon.counter.command
 
 import com.cobblemon.mod.common.command.argument.PokemonArgumentType
+import com.cobblemon.mod.common.command.argument.PokemonPropertiesArgumentType
 import com.mojang.brigadier.context.CommandContext
 import net.minecraft.command.argument.EntityArgumentType
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.text.Text
 import us.timinc.mc.cobblemon.counter.api.CaptureApi
+import us.timinc.mc.cobblemon.counter.store.PokemonIdentifier
 
 object CaptureCountCommand {
     fun withPlayer(ctx: CommandContext<ServerCommandSource>): Int {
+        val pokemonId = Commands.getPokemonIdFromContext(ctx) ?: throw Commands.NO_SPECIES_EXCEPTION.create()
         return check(
-            ctx,
-            EntityArgumentType.getPlayer(ctx, "player"),
-            PokemonArgumentType.getPokemon(ctx, "species").name.lowercase()
+            ctx, EntityArgumentType.getPlayer(ctx, "player"), pokemonId
         )
     }
 
     fun withoutPlayer(ctx: CommandContext<ServerCommandSource>): Int {
+        val pokemonId = Commands.getPokemonIdFromContext(ctx) ?: throw Commands.NO_SPECIES_EXCEPTION.create()
         return ctx.source.player?.let { player ->
             check(
                 ctx,
                 player,
-                PokemonArgumentType.getPokemon(ctx, "species").name.lowercase()
+                pokemonId
             )
         } ?: 0
     }
 
-    private fun check(ctx: CommandContext<ServerCommandSource>, player: PlayerEntity, species: String): Int {
-        val score = CaptureApi.getCount(player, species)
-        ctx.source.sendMessage(Text.translatable("counter.capture.count", player.displayName, score, species))
+    private fun check(
+        ctx: CommandContext<ServerCommandSource>, player: PlayerEntity, pokemonIdentifier: PokemonIdentifier
+    ): Int {
+        val score = CaptureApi.getCount(player, pokemonIdentifier)
+        ctx.source.sendMessage(
+            Text.translatable(
+                "counter.capture.count", player.displayName, score, pokemonIdentifier.species, pokemonIdentifier.form
+            )
+        )
         return score
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/CaptureCountCommand.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/CaptureCountCommand.kt
@@ -1,7 +1,5 @@
 package us.timinc.mc.cobblemon.counter.command
 
-import com.cobblemon.mod.common.command.argument.PokemonArgumentType
-import com.cobblemon.mod.common.command.argument.PokemonPropertiesArgumentType
 import com.mojang.brigadier.context.CommandContext
 import net.minecraft.command.argument.EntityArgumentType
 import net.minecraft.entity.player.PlayerEntity

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/CaptureStreakCommand.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/CaptureStreakCommand.kt
@@ -26,9 +26,17 @@ object CaptureStreakCommand {
 
     private fun check(ctx: CommandContext<ServerCommandSource>, player: PlayerEntity): Int {
         val streakData = CaptureApi.getStreak(player)
-        val species = streakData.first
+        val pokemonId = streakData.first
         val count = streakData.second
-        ctx.source.sendMessage(Text.translatable("counter.capture.streak", player.displayName, count, species))
+        ctx.source.sendMessage(
+            Text.translatable(
+                "counter.capture.streak",
+                player.displayName,
+                count,
+                pokemonId.species,
+                pokemonId.form
+            )
+        )
         return count
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/Commands.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/Commands.kt
@@ -1,0 +1,21 @@
+package us.timinc.mc.cobblemon.counter.command
+
+import com.cobblemon.mod.common.api.text.red
+import com.cobblemon.mod.common.command.argument.PokemonPropertiesArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import net.minecraft.server.command.ServerCommandSource
+import net.minecraft.text.Text
+import us.timinc.mc.cobblemon.counter.store.PokemonIdentifier
+
+object Commands {
+    const val PROPERTIES = "properties"
+    val NO_SPECIES_EXCEPTION = SimpleCommandExceptionType(Text.literal("Invalid species!").red())
+    fun getPokemonIdFromContext(ctx: CommandContext<ServerCommandSource>): PokemonIdentifier? {
+        val properties = PokemonPropertiesArgumentType.getPokemonProperties(ctx, "properties")
+        if (properties.species == null) {
+            return null
+        }
+        return PokemonIdentifier(properties.species!!, properties.form ?: "")
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/KoCountCommand.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/KoCountCommand.kt
@@ -7,29 +7,44 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.server.command.ServerCommandSource
 import net.minecraft.text.Text
 import us.timinc.mc.cobblemon.counter.api.KoApi
+import us.timinc.mc.cobblemon.counter.store.PokemonIdentifier
 
 object KoCountCommand {
     fun withPlayer(ctx: CommandContext<ServerCommandSource>): Int {
+        val pokemonId = Commands.getPokemonIdFromContext(ctx) ?: throw Commands.NO_SPECIES_EXCEPTION.create()
         return check(
             ctx,
             EntityArgumentType.getPlayer(ctx, "player"),
-            PokemonArgumentType.getPokemon(ctx, "species").name.lowercase()
+            pokemonId
         )
     }
 
     fun withoutPlayer(ctx: CommandContext<ServerCommandSource>): Int {
+        val pokemonId = Commands.getPokemonIdFromContext(ctx) ?: throw Commands.NO_SPECIES_EXCEPTION.create()
         return ctx.source.player?.let { player ->
             check(
                 ctx,
                 player,
-                PokemonArgumentType.getPokemon(ctx, "species").name.lowercase()
+                pokemonId
             )
         } ?: 0
     }
 
-    private fun check(ctx: CommandContext<ServerCommandSource>, player: PlayerEntity, species: String): Int {
-        val score = KoApi.getCount(player, species)
-        ctx.source.sendMessage(Text.translatable("counter.ko.count", player.displayName, score, species))
+    private fun check(
+        ctx: CommandContext<ServerCommandSource>,
+        player: PlayerEntity,
+        pokemonId: PokemonIdentifier
+    ): Int {
+        val score = KoApi.getCount(player, pokemonId)
+        ctx.source.sendMessage(
+            Text.translatable(
+                "counter.ko.count",
+                player.displayName,
+                score,
+                pokemonId.species,
+                pokemonId.form
+            )
+        )
         return score
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/KoCountCommand.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/KoCountCommand.kt
@@ -1,6 +1,5 @@
 package us.timinc.mc.cobblemon.counter.command
 
-import com.cobblemon.mod.common.command.argument.PokemonArgumentType
 import com.mojang.brigadier.context.CommandContext
 import net.minecraft.command.argument.EntityArgumentType
 import net.minecraft.entity.player.PlayerEntity

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/KoStreakCommand.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/command/KoStreakCommand.kt
@@ -26,9 +26,17 @@ object KoStreakCommand {
 
     private fun check(ctx: CommandContext<ServerCommandSource>, player: PlayerEntity): Int {
         val streakData = KoApi.getStreak(player)
-        val species = streakData.first
+        val pokemonId = streakData.first
         val count = streakData.second
-        ctx.source.sendMessage(Text.translatable("counter.ko.streak", player.displayName, count, species))
+        ctx.source.sendMessage(
+            Text.translatable(
+                "counter.ko.streak",
+                player.displayName,
+                count,
+                pokemonId.species,
+                pokemonId.form
+            )
+        )
         return count
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/CaptureCount.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/CaptureCount.kt
@@ -2,7 +2,6 @@ package us.timinc.mc.cobblemon.counter.store
 
 import com.cobblemon.mod.common.api.storage.player.PlayerDataExtension
 import com.google.gson.JsonObject
-import us.timinc.mc.cobblemon.counter.Counter
 
 class CaptureCount : PlayerDataExtension {
     companion object {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/CaptureCount.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/CaptureCount.kt
@@ -2,25 +2,26 @@ package us.timinc.mc.cobblemon.counter.store
 
 import com.cobblemon.mod.common.api.storage.player.PlayerDataExtension
 import com.google.gson.JsonObject
+import us.timinc.mc.cobblemon.counter.Counter
 
 class CaptureCount : PlayerDataExtension {
     companion object {
         const val NAME = "captureCount"
     }
 
-    private val captureCounts = mutableMapOf<String, Int>()
+    private val captureCounts = mutableMapOf<PokemonIdentifier, Int>()
 
     fun reset() {
         captureCounts.clear()
     }
 
-    fun add(speciesName: String) {
-        captureCounts[speciesName] =
-            get(speciesName) + 1
+    fun add(pokemonIdentifier: PokemonIdentifier) {
+        captureCounts[pokemonIdentifier] =
+            get(pokemonIdentifier) + 1
     }
 
-    fun get(speciesName: String): Int {
-        return captureCounts.getOrDefault(speciesName, 0)
+    fun get(pokemonIdentifier: PokemonIdentifier): Int {
+        return captureCounts.getOrDefault(pokemonIdentifier, 0)
     }
 
     fun total(): Int {
@@ -29,8 +30,9 @@ class CaptureCount : PlayerDataExtension {
 
     override fun deserialize(json: JsonObject): CaptureCount {
         val defeatsData = json.getAsJsonObject("defeats")
-        for (speciesName in defeatsData.keySet()) {
-            captureCounts[speciesName] = defeatsData.get(speciesName).asInt
+        for (jsonKey in defeatsData.keySet()) {
+            val pokemonId = PokemonIdentifier.fromJsonKey(jsonKey)
+            captureCounts[pokemonId] = defeatsData.get(jsonKey).asInt
         }
 
         return this
@@ -40,13 +42,19 @@ class CaptureCount : PlayerDataExtension {
         return NAME
     }
 
+    // "name": "captureCount",
+    // "defeats": {
+    //      "sneasel": 7,
+    //      "sneasel+hisuian": 2
+    // }
+
     override fun serialize(): JsonObject {
         val json = JsonObject()
         json.addProperty("name", NAME)
 
         val defeatsData = JsonObject()
-        for (speciesName in captureCounts.keys) {
-            defeatsData.addProperty(speciesName, captureCounts[speciesName])
+        for (pokemonId in captureCounts.keys) {
+            defeatsData.addProperty(pokemonId.jsonKey(), captureCounts[pokemonId])
         }
         json.add("defeats", defeatsData)
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/CaptureStreak.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/CaptureStreak.kt
@@ -8,32 +8,36 @@ class CaptureStreak : PlayerDataExtension {
         const val NAME = "captureStreak"
     }
 
-    var species = ""
+    var pokemonId = PokemonIdentifier("", "")
     var count = 0
 
     fun reset() {
-        species = ""
+        pokemonId = PokemonIdentifier("", "")
         count = 0
     }
 
-    fun add(speciesName: String) {
-        if (speciesName == species) {
+    fun add(identifier: PokemonIdentifier) {
+        if (identifier == pokemonId) {
             count++
         } else {
-            species = speciesName
+            pokemonId = identifier
             count = 1
         }
     }
 
-    fun get(speciesName: String): Int {
-        if (speciesName == species) {
+    fun get(identifier: PokemonIdentifier): Int {
+        if (identifier == pokemonId) {
             return count
         }
         return 0
     }
 
     override fun deserialize(json: JsonObject): CaptureStreak {
-        species = json.get("species").asString
+        val species = json.get("species").asString
+        val form = if (json.has("form")) {
+            json.get("form").asString
+        } else ""
+        pokemonId = PokemonIdentifier(species, form)
         count = json.get("count").asInt
 
         return this
@@ -47,7 +51,8 @@ class CaptureStreak : PlayerDataExtension {
         val json = JsonObject()
 
         json.addProperty("name", NAME)
-        json.addProperty("species", species)
+        json.addProperty("species", pokemonId.species)
+        json.addProperty("form", pokemonId.form)
         json.addProperty("count", count)
 
         return json

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/KoCount.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/KoCount.kt
@@ -8,18 +8,18 @@ class KoCount : PlayerDataExtension {
         const val NAME = "koCount"
     }
 
-    private val koCounts = mutableMapOf<String, Int>()
+    private val koCounts = mutableMapOf<PokemonIdentifier, Int>()
 
     fun reset() {
         koCounts.clear()
     }
 
-    fun add(speciesName: String) {
-        koCounts[speciesName] = get(speciesName) + 1
+    fun add(identifier: PokemonIdentifier) {
+        koCounts[identifier] = get(identifier) + 1
     }
 
-    fun get(speciesName: String): Int {
-        return koCounts.getOrDefault(speciesName, 0)
+    fun get(identifier: PokemonIdentifier): Int {
+        return koCounts.getOrDefault(identifier, 0)
     }
 
     fun total(): Int {
@@ -28,8 +28,9 @@ class KoCount : PlayerDataExtension {
 
     override fun deserialize(json: JsonObject): KoCount {
         val defeatsData = json.getAsJsonObject("defeats")
-        for (speciesName in defeatsData.keySet()) {
-            koCounts[speciesName] = defeatsData.get(speciesName).asInt
+        for (jsonKey in defeatsData.keySet()) {
+            val pokemonId = PokemonIdentifier.fromJsonKey(jsonKey)
+            koCounts[pokemonId] = defeatsData.get(jsonKey).asInt
         }
 
         return this
@@ -44,8 +45,9 @@ class KoCount : PlayerDataExtension {
         json.addProperty("name", NAME)
 
         val defeatsData = JsonObject()
-        for (speciesName in koCounts.keys) {
-            defeatsData.addProperty(speciesName, koCounts[speciesName])
+        for (identifier in koCounts.keys) {
+            val key = identifier.jsonKey()
+            defeatsData.addProperty(key, koCounts[identifier])
         }
         json.add("defeats", defeatsData)
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/KoStreak.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/KoStreak.kt
@@ -8,32 +8,36 @@ class KoStreak : PlayerDataExtension {
         const val NAME = "koStreak"
     }
 
-    var species = ""
+    var pokemonId = PokemonIdentifier("", "")
     var count = 0
 
     fun reset() {
-        species = ""
+        pokemonId = PokemonIdentifier("", "")
         count = 0
     }
 
-    fun add(speciesName: String) {
-        if (speciesName == species) {
+    fun add(identifier: PokemonIdentifier) {
+        if (identifier == pokemonId) {
             count++
         } else {
-            species = speciesName
+            pokemonId = identifier
             count = 1
         }
     }
 
-    fun get(speciesName: String): Int {
-        if (speciesName == species) {
+    fun get(identifier: PokemonIdentifier): Int {
+        if (identifier == pokemonId) {
             return count
         }
         return 0
     }
 
     override fun deserialize(json: JsonObject): KoStreak {
-        species = json.get("species").asString
+        val species = json.get("species").asString
+        val form = if (json.has("form")) {
+            json.get("form").asString
+        } else ""
+        pokemonId = PokemonIdentifier(species, form)
         count = json.get("count").asInt
 
         return this
@@ -47,7 +51,8 @@ class KoStreak : PlayerDataExtension {
         val json = JsonObject()
 
         json.addProperty("name", NAME)
-        json.addProperty("species", species)
+        json.addProperty("species", pokemonId.species)
+        json.addProperty("form", pokemonId.form)
         json.addProperty("count", count)
 
         return json

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/PokemonIdentifier.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/PokemonIdentifier.kt
@@ -1,0 +1,20 @@
+package us.timinc.mc.cobblemon.counter.store
+
+class PokemonIdentifier(val species: String, form: String) {
+    // Filter out "Normal" form to "". Pikachu's (and maybe others?) Normal form is "base".
+    val form: String = if (form.lowercase() == "normal" || form.lowercase() == "base") "" else form
+
+    companion object {
+        fun fromJsonKey(key: String): PokemonIdentifier {
+            val strings = key.split('+', limit = 2)
+            return if (strings.size == 1) PokemonIdentifier(strings[0].replaceFirstChar { it.uppercaseChar() }, "")
+            else PokemonIdentifier(
+                strings[0].replaceFirstChar { it.uppercaseChar() },
+                strings[1].replaceFirstChar { it.uppercaseChar() })
+        }
+    }
+
+    fun jsonKey(): String {
+        return "${species.lowercase()}+${form.lowercase()}"
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/PokemonIdentifier.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/counter/store/PokemonIdentifier.kt
@@ -1,16 +1,16 @@
 package us.timinc.mc.cobblemon.counter.store
 
 class PokemonIdentifier(val species: String, form: String) {
-    // Filter out "Normal" form to "". Pikachu's (and maybe others?) Normal form is "base".
-    val form: String = if (form.lowercase() == "normal" || form.lowercase() == "base") "" else form
+    // Filter out "Normal" form to "".
+    val form: String = if (form.lowercase() == "normal") "" else form
 
     companion object {
         fun fromJsonKey(key: String): PokemonIdentifier {
             val strings = key.split('+', limit = 2)
             return if (strings.size == 1) PokemonIdentifier(strings[0].replaceFirstChar { it.uppercaseChar() }, "")
             else PokemonIdentifier(
-                strings[0].replaceFirstChar { it.uppercaseChar() },
-                strings[1].replaceFirstChar { it.uppercaseChar() })
+                    strings[0].replaceFirstChar { it.uppercaseChar() },
+                    strings[1].replaceFirstChar { it.uppercaseChar() })
         }
     }
 

--- a/src/main/resources/assets/cobblemon_counter/lang/en_us.json
+++ b/src/main/resources/assets/cobblemon_counter/lang/en_us.json
@@ -1,9 +1,9 @@
 {
-    "counter.ko.count": "%d has ko'd %d %d",
-    "counter.ko.streak": "%d has a ko streak of %d %d",
+    "counter.ko.count": "%d has ko'd %d %d %d",
+    "counter.ko.streak": "%d has a ko streak of %d %d %d",
     "counter.ko.total": "%d has ko'd %d total Pokemon",
-    "counter.capture.count": "%d has captured %d %d",
-    "counter.capture.streak": "%d has a capture streak of %d %d",
+    "counter.capture.count": "%d has captured %d %d %d",
+    "counter.capture.streak": "%d has a capture streak of %d %d %d",
     "counter.capture.total": "%d has captured %d total Pokemon",
     "counter.ko.count.reset": "KO count data reset for %d",
     "counter.ko.streak.reset": "KO streak data reset for %d",
@@ -11,6 +11,6 @@
     "counter.capture.count.reset": "Capture count data reset for %d",
     "counter.capture.streak.reset": "Capture streak data reset for %d",
     "counter.capture.all.reset": "Capture data reset for %d",
-    "counter.capture.confirm": "Captured %d (%d/%d)",
-    "counter.ko.confirm": "KO'd %d (%d/%d)"
+    "counter.capture.confirm": "Captured %d %d (%d/%d)",
+    "counter.ko.confirm": "KO'd %d %d (%d/%d)"
 }


### PR DESCRIPTION
Currently Counter does not support multiple forms as capture / KO data is stored only by Pokemon name, but alternate Pokemon forms have the same name, so the implementation doesn't work for multiple forms.
With this change, data is stored by (name + form). JSON looks like ie:
```json
    "captureCount": {
      "name": "captureCount",
      "defeats": {
        "pikachu": 2,
        "pikachu+alolan": 2,
        "arbok": 3,
        "gloom": 2,
        "mimikyu": 2,
        "farfetch�d": 1,
        "farfetch�d+galar": 1
      }
    },
```
Base forms are still stored the same way, so as far as I can tell this shouldn't break backwards compatibility for existing worlds.
Although the API does change, so any dependencies would have to update.